### PR TITLE
Update modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^3.15.0",
+    "eslint": "^5.16.0",
     "mocha": "^6.1.4",
     "testdouble": "^3.11.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "eslint": "^3.15.0",
-    "mocha": "^3.2.0",
-    "testdouble": "^1.11.1"
+    "mocha": "^6.1.4",
+    "testdouble": "^3.11.0"
   },
   "dependencies": {
     "got": "^6.7.1"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "author": "Mark Castillo",
   "license": "MIT",
   "devDependencies": {
-    "chai": "^3.5.0",
-    "chai-as-promised": "^6.0.0",
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^3.15.0",
     "mocha": "^6.1.4",
     "testdouble": "^3.11.0"

--- a/test/api.js
+++ b/test/api.js
@@ -1,8 +1,8 @@
 const {replace, when, verify, matchers: {
-  anything,
-  contains,
-  argThat
-}} = require('testdouble')
+    anything,
+    contains,
+    argThat
+  }} = require('testdouble')
   , URL = require('url')
   , {API_VERSION, API_HOST} = require('./../src/defaults');
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 const {replace, when, verify, object, matchers: {
-  anything,
-  argThat
-}} = require('testdouble')
+    anything,
+    argThat
+  }} = require('testdouble')
   , data = require('./../src/data')
   , {CURRENT_CONGRESS} = require('./../src/defaults');
 


### PR DESCRIPTION
I updated the modules, since npm audit was unhappy and tests were failing.

Tests are still giving lots of warnings like this, which I don't know testdouble enough to fix:

> Warning: testdouble.js - td.verify - test double `.get` was both stubbed and verified with arguments (anything(), 0), which is redundant and probably unnecessary. (see: https://github.com/testdouble/testdouble.js/blob/master/docs/B-frequently-asked-questions.md#why-shouldnt-i-call-both-tdwhen-and-tdverify-for-a-single-interaction-with-a-test-double )
