### PR TITLE
fix number for current Congress

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ yarn add propublica-congress
 ## Usage
 
 ```javascript
-const ppc = require('propublica-congress').create('PROPUBLICA_API_KEY');
+const congress = 116;
+const ppc = require('propublica-congress').create('PROPUBLICA_API_KEY', congress);
 
 ppc.getCurrentSenators('NY')
   .then(results => console.log(results));

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,5 +1,5 @@
 module.exports = {
   API_VERSION: '1',
   API_HOST: 'https://api.propublica.org',
-  CURRENT_CONGRESS: 115
+  CURRENT_CONGRESS: Math.floor((new Date().getFullYear() - 1787) / 2),
 };

--- a/test/validators.js
+++ b/test/validators.js
@@ -1,6 +1,7 @@
 const chai = require('chai')
   , states = require('./../src/data/states')
-  , validators = require('./../src/validators');
+  , validators = require('./../src/validators')
+  , {CURRENT_CONGRESS} = require('./../src/defaults');
 
 chai.should();
 
@@ -78,12 +79,12 @@ describe('validators', () => {
   describe('isValidCongress()', () => {
     context('without a lower limit', () => {
       it('accepts the current session and lower', () => {
-        validators.isValidCongress(115).should.be.true;
+        validators.isValidCongress(CURRENT_CONGRESS).should.be.true;
         validators.isValidCongress(100).should.be.true;
       });
 
       it('rejects any sessions past the current congress', () => {
-        validators.isValidCongress(116).should.be.false;
+        validators.isValidCongress(CURRENT_CONGRESS + 1).should.be.false;
         validators.isValidCongress(200).should.be.false;
       });
 
@@ -97,7 +98,7 @@ describe('validators', () => {
 
     context('with a lower limit', () => {
       it('rejects any sessions past the current congress', () => {
-        validators.isValidCongress(116, 108).should.be.false;
+        validators.isValidCongress(CURRENT_CONGRESS + 1, 108).should.be.false;
         validators.isValidCongress(200, 108).should.be.false;
       });
 


### PR DESCRIPTION
It was breaking for the current Congress, so I made it default to the actual current Congress but added the congress argument to the example in the readme because omitting it would be a bad idea anyway.

Or maybe for backward compatibility it should default to 115 but omitting the argument should be deprecated.